### PR TITLE
Refactor terminal and entrypoint configuration flow

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,58 @@
 import os
 import pathlib
+from unittest import mock
 
 import pytest
+
+
+class SimpleMocker:
+    """Lightweight replacement for the ``pytest-mock`` fixture."""
+
+    class _PatchProxy:
+        def __init__(self, helper: "SimpleMocker") -> None:
+            self._helper = helper
+
+        def __call__(self, target: str, *args, **kwargs):
+            patcher = mock.patch(target, *args, **kwargs)
+            started = patcher.start()
+            self._helper._patches.append(patcher)
+            return started
+
+        def object(self, target, attribute, *args, **kwargs):
+            patcher = mock.patch.object(target, attribute, *args, **kwargs)
+            started = patcher.start()
+            self._helper._patches.append(patcher)
+            return started
+
+        def dict(self, in_dict, values=(), clear: bool = False):
+            patcher = mock.patch.dict(in_dict, values, clear=clear)
+            patcher.start()
+            self._helper._patches.append(patcher)
+            return patcher
+
+    def __init__(self) -> None:
+        self._patches: list[mock._patch] = []
+        self.patch = SimpleMocker._PatchProxy(self)
+
+    def stopall(self) -> None:
+        for patcher in reversed(self._patches):
+            patcher.stop()
+        self._patches.clear()
+
+    def Mock(self, *args, **kwargs):  # noqa: N802 - match pytest-mock API
+        return mock.Mock(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(mock, name)
+
+
+@pytest.fixture
+def mocker():
+    helper = SimpleMocker()
+    try:
+        yield helper
+    finally:
+        helper.stopall()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -30,7 +30,6 @@ def test_preflight_fails_if_command_missing(mocker, mock_tool):
             _which=lambda cmd: None,
             _err=mock_err,
             _sys_exit=mock_sys_exit,
-            _Progress=MagicMock(),
         )
 
     assert excinfo.value.code == 1
@@ -52,7 +51,6 @@ def test_preflight_requires_key_when_not_local(mocker, mock_tool):
             _os_environ={},
             _warn=mock_warn,
             _sys_exit=mock_sys_exit,
-            _Progress=MagicMock(),
         )
 
     assert excinfo.value.code == 1
@@ -72,7 +70,6 @@ def test_preflight_allows_local_without_key(mocker, mock_tool):
         _which=lambda cmd: "/bin/crush",
         _os_environ={},
         _sys_exit=mock_sys_exit,
-        _Progress=MagicMock(),
     )
 
     mock_sys_exit.assert_not_called()
@@ -89,7 +86,6 @@ def test_preflight_succeeds_with_key_and_command(mocker, mock_tool):
         _which=lambda cmd: "/bin/crush",
         _os_environ=mock_env,
         _sys_exit=mock_sys_exit,
-        _Progress=MagicMock(),
     )
 
     mock_sys_exit.assert_not_called()


### PR DESCRIPTION
## Summary
- streamline Victoria Terminal by loading `.env` automatically, simplifying preflight/launch, and rebuilding Crush configuration generation and CLI options
- simplify the container entry point to sync a shared `~/Victoria` directory, prompt for configuration when needed, and reuse the updated terminal workflow
- add an internal `mocker` test fixture and refresh unit tests to reflect the lighter-weight helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68c8b5a6e7508332bcdb351c1905a316