### PR TITLE
[VictoriaTerminal] Simplify Crush config and relax tests

### DIFF
--- a/configs/crush/crush.template.json
+++ b/configs/crush/crush.template.json
@@ -2,12 +2,13 @@
   "$schema": "https://charm.land/crush.json",
   "permissions": {
     "allowed_tools": [
-      "view",
-      "ls",
-      "grep",
-      "edit",
-      "motherduck_query"
+      "*"
     ]
+  },
+  "lsp": {
+    "python": {
+      "command": "pylsp"
+    }
   },
   "providers": {
     "openrouter": {

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -26,7 +26,6 @@ def test_preflight_fails_if_command_missing(mocker, mock_tool):
     with pytest.raises(SystemExit) as excinfo:
         preflight_crush(
             mock_tool,
-            use_local_model=False,
             _which=lambda cmd: None,
             _err=mock_err,
             _sys_exit=mock_sys_exit,
@@ -36,56 +35,34 @@ def test_preflight_fails_if_command_missing(mocker, mock_tool):
     mock_err.assert_called_with(
         "Missing 'crush' command-line tool. Rebuild the Victoria container or install the CLI in your environment."
     )
+def test_preflight_warns_when_key_missing(mocker, mock_tool):
+    """Preflight should warn about missing OpenRouter credentials but continue."""
 
-
-def test_preflight_requires_key_when_not_local(mocker, mock_tool):
-    """Test that preflight fails if OPENROUTER_API_KEY is missing for non-local models."""  # noqa: E501
     mock_warn = mocker.Mock()
-    mock_sys_exit = mocker.Mock(side_effect=SystemExit(1))
-
-    with pytest.raises(SystemExit) as excinfo:
-        preflight_crush(
-            mock_tool,
-            use_local_model=False,
-            _which=lambda cmd: "/bin/crush",
-            _os_environ={},
-            _warn=mock_warn,
-            _sys_exit=mock_sys_exit,
-        )
-
-    assert excinfo.value.code == 1
-    mock_warn.assert_called_with(
-        "OPENROUTER_API_KEY not configured. "
-        "Run the Victoria container entrypoint to add it or select the local model option."
-    )
-
-
-def test_preflight_allows_local_without_key(mocker, mock_tool):
-    """Test that preflight succeeds without an API key for local models."""
     mock_sys_exit = mocker.Mock()
 
     preflight_crush(
         mock_tool,
-        use_local_model=True,
         _which=lambda cmd: "/bin/crush",
         _os_environ={},
+        _warn=mock_warn,
         _sys_exit=mock_sys_exit,
     )
 
+    mock_warn.assert_called_once()
     mock_sys_exit.assert_not_called()
 
 
-def test_preflight_succeeds_with_key_and_command(mocker, mock_tool):
-    """Test the happy path where command exists and key is present."""
-    mock_sys_exit = mocker.Mock()
-    mock_env = {"OPENROUTER_API_KEY": "fake-key"}
+def test_preflight_reports_key_present(mocker, mock_tool):
+    """A configured API key should be acknowledged."""
+
+    mock_good = mocker.Mock()
 
     preflight_crush(
         mock_tool,
-        use_local_model=False,
         _which=lambda cmd: "/bin/crush",
-        _os_environ=mock_env,
-        _sys_exit=mock_sys_exit,
+        _os_environ={"OPENROUTER_API_KEY": "fake-key"},
+        _good=mock_good,
     )
 
-    mock_sys_exit.assert_not_called()
+    assert any("OpenRouter API key configured" in str(call.args[0]) for call in mock_good.call_args_list)

--- a/tests/test_system_interaction.py
+++ b/tests/test_system_interaction.py
@@ -103,7 +103,7 @@ def test_launch_tool_unix(mocker):
         _sys_exit=mock_sys_exit,
     )
 
-    mock_execvp.assert_called_once_with("crush", ["crush", "-c", str(fake_home)])
+    mock_execvp.assert_called_once_with("crush", ["crush", "-c", str(fake_home), "--yolo"])
     mock_sys_exit.assert_not_called()
 
 
@@ -122,7 +122,7 @@ def test_launch_tool_windows(mocker):
         _sys_exit=mock_sys_exit,
     )
 
-    mock_run.assert_called_once_with(["crush", "-c", str(fake_home)])
+    mock_run.assert_called_once_with(["crush", "-c", str(fake_home), "--yolo"])
     mock_sys_exit.assert_not_called()
 
 

--- a/tests/test_user_interaction.py
+++ b/tests/test_user_interaction.py
@@ -1,25 +1,13 @@
-from VictoriaTerminal import course_menu, local_model_menu
+from VictoriaTerminal import snowflake_credentials_prompt
 from victoria_entrypoint import prompt_for_configuration, SNOWFLAKE_ENV_VARS
+def test_snowflake_credentials_prompt_yes(mocker):
+    mocker.patch("VictoriaTerminal.Confirm.ask", return_value=True)
+    assert snowflake_credentials_prompt() is True
 
 
-def test_local_model_menu_yes(mocker):
-    mocker.patch("rich.prompt.Prompt.ask", return_value="y")
-    assert local_model_menu() is True
-
-
-def test_local_model_menu_no(mocker):
-    mocker.patch("rich.prompt.Prompt.ask", return_value="n")
-    assert local_model_menu() is False
-
-
-def test_course_menu_one(mocker):
-    mocker.patch("rich.prompt.Prompt.ask", return_value="1")
-    assert course_menu() == "1"
-
-
-def test_course_menu_two(mocker):
-    mocker.patch("rich.prompt.Prompt.ask", return_value="2")
-    assert course_menu() == "2"
+def test_snowflake_credentials_prompt_no(mocker):
+    mocker.patch("VictoriaTerminal.Confirm.ask", return_value=False)
+    assert snowflake_credentials_prompt() is False
 
 
 def test_prompt_for_configuration_openrouter_retry(mocker):


### PR DESCRIPTION
## Summary
- simplify Crush configuration generation by always merging Snowflake and LM Studio providers and enabling Snowflake credential checks via a new prompt/CLI flag
- run the terminal in Crush `--yolo` mode and widen default permissions/LSP support in the bundled crush.json template
- streamline preflight behavior and refresh tests to cover the new defaults without brittle environment coupling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8bec37a108332b8687f23bf17db01