### PR TITLE
[CI] Normalize container image name in workflow

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ toLower(github.repository) }}
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build-and-push:
@@ -19,6 +19,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Normalize image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Log in to registry
         uses: redhat-actions/podman-login@v1


### PR DESCRIPTION
## Summary
- replace the unsupported `toLower` expression in the container image workflow
- add a normalization step that lower-cases the repository name for image tags

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68c8c3e44c508332a455d3effeede947