### PR TITLE
[CI] Update build image workflow for buildah v2

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build image
         id: build-image
-        uses: redhat-actions/buildah-build@v1
+        uses: redhat-actions/buildah-build@v2
         with:
           containerfiles: Containerfile
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}


### PR DESCRIPTION
## Summary
- switch the container-image workflow to use redhat-actions/buildah-build@v2 so the containerfiles/tags inputs are honored

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68c8c4b762a08332ba9624d4f81f26f3