### PR TITLE
[Container] Use Fedora latest base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:40
+FROM registry.fedoraproject.org/fedora:latest
 
 ENV PATH="/root/.local/bin:${PATH}" \
     PYTHONUNBUFFERED="1"


### PR DESCRIPTION
## Summary
- update the Podman/Containerfile base image tag to Fedora latest to automatically track new releases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8c6292a188332b69c48fc1c7665fe