### PR TITLE
[CI] Provide registry to container push action

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -45,3 +45,4 @@ jobs:
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
## Summary
- pass the container registry name to the push-to-registry action so short tags are accepted

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8c6b2e9288332822d804278dfc286