### PR TITLE
[Container] Build crush via go install

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,10 +4,9 @@ ENV PATH="/root/.local/bin:${PATH}" \
     PYTHONUNBUFFERED="1"
 
 RUN dnf -y upgrade && \
-    dnf -y install python3 python3-pip git curl && \
-    printf "[charm]\nname=Charm\nbaseurl=https://repo.charm.sh/yum/\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.charm.sh/yum/gpg.key\n" > /etc/yum.repos.d/charm.repo && \
-    dnf -y install crush && \
-    dnf clean all && rm -rf /var/cache/dnf
+    dnf -y install python3 python3-pip git curl golang && \
+    GOBIN=/usr/local/bin go install github.com/charmbracelet/crush@latest && \
+    dnf clean all && rm -rf /var/cache/dnf && rm -rf /root/go/pkg/mod
 
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 


### PR DESCRIPTION
## Summary
- install Golang from the Fedora repositories in the container image
- build the crush CLI using `go install` instead of the Charm yum repository
- clean up Go module caches after installation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8cca9f14c8332879ac1da71183b6c