### PR TITLE
[VictoriaTerminal] Allow Containerfile to install latest crush

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,8 @@
 FROM registry.fedoraproject.org/fedora:latest
 
 ENV PATH="/root/.local/bin:${PATH}" \
-    PYTHONUNBUFFERED="1"
+    PYTHONUNBUFFERED="1" \
+    GOTOOLCHAIN="auto"
 
 RUN dnf -y upgrade && \
     dnf -y install python3 python3-pip git curl golang && \


### PR DESCRIPTION
## Summary
- keep `GOTOOLCHAIN=auto` so the build can download newer Go toolchains as needed
- install `github.com/charmbracelet/crush` from `@latest` to match upstream releases

## Testing
- not run (container build not executed in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68c8ced03d008332b6cb3f1c5887d817