### PR TITLE
[Container] Ensure Go toolchain verification succeeds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -2,7 +2,8 @@ FROM registry.fedoraproject.org/fedora:latest
 
 ENV PATH="/root/.local/bin:${PATH}" \
     PYTHONUNBUFFERED="1" \
-    GOTOOLCHAIN="auto"
+    GOTOOLCHAIN="auto" \
+    GOSUMDB="sum.golang.org"
 
 RUN dnf -y upgrade && \
     dnf -y install python3 python3-pip git curl golang && \


### PR DESCRIPTION
## Summary
- set `GOSUMDB` to `sum.golang.org` in the container image so Go can verify toolchain downloads when installing `crush`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8d03d42e08332a2b6d88a7c120842