### PR TITLE
[Automation] Add arm64 container build job

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -46,3 +46,39 @@ jobs:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
           registry: ${{ env.REGISTRY }}
+
+  build-and-push-arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Normalize image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image (arm64)
+        id: build-image-arm64
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: Containerfile
+          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            latest-arm64
+            ${{ github.sha }}-arm64
+
+      - name: Push image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image-arm64.outputs.image }}
+          tags: ${{ steps.build-image-arm64.outputs.tags }}
+          registry: ${{ env.REGISTRY }}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ podman run --rm -it \
   ghcr.io/elcanotek/victoria-terminal:latest
 ```
 
+> [!TIP]
+> On Arm64 hardware such as Apple silicon Macs, use the dedicated Arm build:
+>
+> ```bash
+> podman run --rm -it \
+>   -v ~/Victoria:/root/Victoria \
+>   ghcr.io/elcanotek/victoria-terminal:latest-arm64
+> ```
+>
+> The workflow also publishes a commit-specific tag that includes the suffix `-arm64` if you need to pin to an exact build.
+
 Mounting `~/Victoria` ensures that the entry point can reuse your configuration and generated project files across container sessions.
 
 To pass options directly to `VictoriaTerminal.py`, append them after `--`:


### PR DESCRIPTION
## Summary
- add an arm64 GitHub Actions job that publishes architecture-specific tags
- document the new arm64 container tag for Apple silicon and other Arm64 users

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c8d411bc8c833288c256692908c84c