### PR TITLE
[Docs] Document shared Victoria directory setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ podman build -t victoria-terminal .
 
 A GitHub Action automatically builds and publishes the image to the GitHub Container Registry. Pull and run the latest image with Podman:
 
+Before running the container, make sure the shared directory exists on your host machine. Create it once with the command that
+matches your operating system:
+
+* **macOS / Linux**: `mkdir -p ~/Victoria`
+* **Windows (PowerShell)**: `New-Item -ItemType Directory -Path "$HOME/Victoria" -Force`
+* **Windows (Command Prompt)**: `mkdir %USERPROFILE%\Victoria`
+
 ```bash
 podman run --rm -it \
   -v ~/Victoria:/root/Victoria \


### PR DESCRIPTION
## Summary
- instruct users to create the shared `~/Victoria` directory before running the container
- document platform-specific commands for creating the directory on macOS, Linux, and Windows

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_b_68c8d5f02e4c83328c890f0cd1b04c0c