### PR TITLE
[VictoriaTerminal] Fix Crush LSP command schema

### DIFF
--- a/configs/crush/crush.template.json
+++ b/configs/crush/crush.template.json
@@ -7,11 +7,7 @@
   },
   "lsp": {
     "python": {
-      "command": [
-        "python",
-        "-m",
-        "pylsp"
-      ]
+      "command": "python -m pylsp"
     }
   },
   "providers": {

--- a/tests/test_victoria_entrypoint.py
+++ b/tests/test_victoria_entrypoint.py
@@ -86,6 +86,8 @@ def test_generate_crush_config_substitutes_env(tmp_path: Path) -> None:
     data = json.loads(output.read_text(encoding="utf-8"))
     assert data["providers"]["openrouter"]["api_key"] == "test-key"
 
+    assert data["lsp"]["python"]["command"] == "python -m pylsp"
+
     motherduck_cmd = data["mcp"]["motherduck"]["command"]
     assert motherduck_cmd[-1] == str(tmp_path / "adtech.duckdb")
 


### PR DESCRIPTION
## Summary
- update the bundled Crush template to use the new string-based LSP command format
- extend the entrypoint test to cover the Python LSP command expectation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c968c117e48332bde6922ce7308372