### PR TITLE
[VictoriaTerminal] Remove bundled LSP server configuration

### DIFF
--- a/configs/crush/crush.template.json
+++ b/configs/crush/crush.template.json
@@ -5,11 +5,6 @@
       "*"
     ]
   },
-  "lsp": {
-    "python": {
-      "command": "python -m pylsp"
-    }
-  },
   "providers": {
     "openrouter": {
       "type": "openai",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,9 +15,6 @@ pandas
 plotly
 polars
 pyarrow
-pylsp-mypy
-python-lsp-ruff
-python-lsp-server
 pytest
 pytest-cov
 pytest-mock

--- a/tests/test_victoria_entrypoint.py
+++ b/tests/test_victoria_entrypoint.py
@@ -86,7 +86,7 @@ def test_generate_crush_config_substitutes_env(tmp_path: Path) -> None:
     data = json.loads(output.read_text(encoding="utf-8"))
     assert data["providers"]["openrouter"]["api_key"] == "test-key"
 
-    assert data["lsp"]["python"]["command"] == "python -m pylsp"
+    assert "lsp" not in data
 
     motherduck_cmd = data["mcp"]["motherduck"]["command"]
     assert motherduck_cmd[-1] == str(tmp_path / "adtech.duckdb")


### PR DESCRIPTION
## Summary
- remove the Crush template configuration that launched pylsp
- drop the pylsp-related packages from requirements
- update the entrypoint test to reflect the LSP removal

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c96fb2161483328ac5a37e6f716de2