### PR TITLE
[CI] Fix push workflow registry configuration

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -35,7 +35,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           containerfiles: Containerfile
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          image: ${{ env.IMAGE_NAME }}
           tags: |
             latest
             ${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           containerfiles: Containerfile
-          image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          image: ${{ env.IMAGE_NAME }}
           tags: |
             latest-arm64
             ${{ github.sha }}-arm64


### PR DESCRIPTION
## Summary
- stop building container images with a registry prefix so the push step does not duplicate the registry host

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68c97df84d548332be24b962ef66c9e1