### PR TITLE
[VictoriaTerminal] Prompt for missing credentials and use python-dotenv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ plotly
 polars
 pyarrow
 pylsp-mypy
+python-dotenv
 python-lsp-ruff
 python-lsp-server
 pytest


### PR DESCRIPTION
## Summary
- replace the bespoke .env reader with python-dotenv and keep environment loading behaviour intact
- prompt users to supply missing OpenRouter or Snowflake credentials and persist them back to the .env file
- add tests covering the new interactive credential workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c9852428488332ac58b10f0ac48c58