### PR TITLE
[VictoriaTerminal] Show OpenRouter API key input

### DIFF
--- a/victoria_terminal.py
+++ b/victoria_terminal.py
@@ -236,7 +236,7 @@ def run_setup_wizard(
             )
         else:
             prompt_text = "OpenRouter API key (press Enter to skip): "
-        value = _prompt_value(prompt_text, secret=True)
+        value = _prompt_value(prompt_text)
         if value:
             store_value("OPENROUTER_API_KEY", value)
         elif openrouter_key:


### PR DESCRIPTION
## Summary
- update the setup wizard to prompt for the OpenRouter API key without masking input

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb0ad9da788332978654a7cb7ac0a5