### PR TITLE
[Docs] Improve helper architecture detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,30 @@ New to containers? No problem. This section walks you through the minimum steps 
 > ```
 > Podman Desktop performs these steps automatically the first time it launches.
 
-### 2. Create the shared workspace folder
+### 2. (Optional) Use the helper script
+
+Once Podman is installed, you can let Victoria wire up the remaining pieces for you. The helper scripts below validate that Podman is ready, make sure your `~/Victoria` workspace exists, detect the Podman host architecture (using `podman info` when available with a local fallback), pull the matching container image tag, and add a reusable `victoria` command to your shell profile.
+
+* **macOS / Linux**
+  ```bash
+  curl -fsSL https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.sh | bash
+  ```
+* **Windows (PowerShell)**
+  ```powershell
+  irm https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1 | iex
+  ```
+
+After the helper finishes, open a new terminal session (or reload your profile with `source ~/.bashrc`, `source ~/.zshrc`, or `. $PROFILE`) and start Victoria with a single command:
+
+```bash
+victoria
+```
+
+The helper keeps the `victoria` command up to date for you, so there's no need to copy the longer `podman run` incantation each time.
+
+Re-run the script any time you want to refresh the alias. It will not reinstall Podman for you, but it will remind you to start `podman machine` on macOS and Windows if needed.
+
+### 3. Create the shared workspace folder
 
 Victoria stores configuration and credentials in a folder that is mounted into the container. Create it once and reuse it for every upgrade:
 
@@ -49,7 +72,7 @@ Victoria stores configuration and credentials in a folder that is mounted into t
   mkdir %USERPROFILE%\Victoria
   ```
 
-### 3. Confirm your CPU architecture
+### 4. Confirm your CPU architecture
 
 Victoria publishes multi-architecture tags. If you're unsure which CPU architecture your Podman host is using, check it with:
 
@@ -87,7 +110,7 @@ podman run --rm -it \
 
 Windows users should keep the commands on a single line and use `$env:USERPROFILE/Victoria` in place of `~/Victoria`.
 
-### 4. Configure on first run
+### 5. Configure on first run
 
 The container entry point (`victoria_terminal.py`) guides the initial setup:
 
@@ -107,7 +130,7 @@ You can also point the entry point at an alternate shared location with `--share
 > [!TIP]
 > Swap in the image tag that matches your architecture (from the table above) and adjust the host path syntax for your platform. Windows PowerShell users should run the command on a single line with `$env:USERPROFILE/Victoria`.
 
-### 5. Choose an AI model in Crush
+### 6. Choose an AI model in Crush
 
 When testing **Victoria** in the terminal, we recommend the following models. They have been vetted for compatibility, reliability, and cost.
 

--- a/install_victoria.ps1
+++ b/install_victoria.ps1
@@ -1,0 +1,136 @@
+#!/usr/bin/env pwsh
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[victoria-install] $Message"
+}
+
+function Show-Help {
+    Write-Host @'
+Usage: install_victoria.ps1
+
+This helper validates Podman, prepares the shared Victoria workspace, and
+installs a reusable `victoria` command in your PowerShell profile.
+'@
+}
+
+param(
+    [switch] $Help,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $ExtraArgs
+)
+
+if ($Help) {
+    Show-Help
+    exit 0
+}
+
+if ($ExtraArgs.Count -gt 0) {
+    Write-Error "This script does not accept arguments."
+    Show-Help
+    exit 1
+}
+
+if (-not (Get-Command podman -ErrorAction SilentlyContinue)) {
+    Write-Error "Podman is not installed or not on PATH. Install Podman from https://podman.io and rerun this script."
+}
+
+$podmanVersion = (& podman --version) -split "`n" | Select-Object -First 1
+Write-Info "Podman detected: $podmanVersion"
+
+try {
+    & podman info | Out-Null
+} catch {
+    Write-Info "Podman is installed but not ready. On Windows or macOS, run 'podman machine init' (first time only) and 'podman machine start' before launching Victoria."
+}
+
+$workspace = Join-Path $HOME 'Victoria'
+if (-not (Test-Path $workspace)) {
+    New-Item -ItemType Directory -Path $workspace -Force | Out-Null
+}
+Write-Info "Ensured shared workspace exists at $workspace"
+
+$arch = $null
+try {
+    $arch = & podman info --format '{{.Host.Arch}}'
+    if (-not [string]::IsNullOrWhiteSpace($arch)) {
+        Write-Info "Detected Podman host architecture via podman info: $arch"
+    }
+} catch {
+    $arch = $null
+}
+
+if ([string]::IsNullOrWhiteSpace($arch)) {
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    Write-Info "Using .NET fallback for architecture detection: $arch"
+}
+
+switch ($arch.ToLowerInvariant()) {
+    'arm64' { $imageTag = 'latest-arm64' }
+    'aarch64' { $imageTag = 'latest-arm64' }
+    'x86_64' { $imageTag = 'latest' }
+    'amd64' { $imageTag = 'latest' }
+    default {
+        Write-Info "Unknown architecture '$arch'; defaulting to multi-arch 'latest' tag."
+        $imageTag = 'latest'
+    }
+}
+$image = "ghcr.io/elcanotek/victoria-terminal:$imageTag"
+Write-Info "Using container image $image"
+
+$profilePath = $PROFILE
+
+$profileDir = Split-Path $profilePath -Parent
+if (-not (Test-Path $profileDir)) {
+    New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+}
+if (-not (Test-Path $profilePath)) {
+    New-Item -ItemType File -Path $profilePath -Force | Out-Null
+}
+Write-Info "Updating PowerShell profile at $profilePath"
+
+$startMarker = '# >>> victoria-terminal helper >>>'
+$endMarker = '# <<< victoria-terminal helper <<<'
+
+$content = Get-Content -Path $profilePath -Raw -ErrorAction SilentlyContinue
+if ($null -ne $content) {
+    $pattern = [System.Text.RegularExpressions.Regex]::Escape($startMarker) + '.*?' + [System.Text.RegularExpressions.Regex]::Escape($endMarker)
+    $newContent = [System.Text.RegularExpressions.Regex]::Replace($content, $pattern, '', 'Singleline')
+    if ($newContent -ne $content) {
+        Set-Content -Path $profilePath -Value $newContent
+    }
+}
+
+$functionBlock = @"
+
+$startMarker
+function Invoke-Victoria {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]] $Args
+    )
+    & podman pull $image
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Victoria setup: unable to pull $image. Make sure Podman is running (start 'podman machine' if applicable)."
+        return
+    }
+    & podman run --rm -it `
+        -v `"$env:USERPROFILE/Victoria:/root/Victoria`" `
+        $image @Args
+}
+Set-Alias victoria Invoke-Victoria
+$endMarker
+"@
+Add-Content -Path $profilePath -Value $functionBlock
+
+Write-Info "Added 'victoria' alias to $profilePath"
+
+Write-Info "Pulling the latest container image (this may take a moment)..."
+& podman pull $image
+if ($LASTEXITCODE -ne 0) {
+    Write-Info "Pull failed. Start Podman (or run 'podman machine start') and launch Victoria later with: victoria"
+}
+
+Write-Info "All set! Reload PowerShell (or run '. $profilePath') and start Victoria with: victoria"

--- a/install_victoria.sh
+++ b/install_victoria.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[victoria-install] %s\n' "$1"
+}
+
+error() {
+  printf '[victoria-install] ERROR: %s\n' "$1" >&2
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: install_victoria.sh
+
+This helper validates Podman, prepares the shared Victoria workspace, and
+installs a reusable `victoria` command in your default shell profile.
+USAGE
+}
+
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      error "This script does not accept arguments."
+      usage
+      exit 1
+      ;;
+  esac
+fi
+
+if ! command -v podman >/dev/null 2>&1; then
+  error "Podman is not installed or not on PATH. Install Podman from https://podman.io and rerun this script."
+  exit 1
+fi
+
+log "Podman detected: $(podman --version 2>/dev/null | head -n1)"
+
+if ! podman info >/dev/null 2>&1; then
+  log "Podman is installed but not ready. If you're on macOS or Windows, run 'podman machine init' (first time only) and 'podman machine start' before launching Victoria."
+fi
+
+WORKSPACE_DIR="$HOME/Victoria"
+mkdir -p "$WORKSPACE_DIR"
+log "Ensured shared workspace exists at $WORKSPACE_DIR"
+
+ARCH=""
+if ARCH=$(podman info --format '{{.Host.Arch}}' 2>/dev/null); then
+  log "Detected Podman host architecture via podman info: $ARCH"
+else
+  ARCH=$(uname -m)
+  log "Using uname fallback for architecture detection: $ARCH"
+fi
+
+case "$ARCH" in
+  arm64|aarch64)
+    IMAGE_TAG="latest-arm64"
+    ;;
+  x86_64|amd64)
+    IMAGE_TAG="latest"
+    ;;
+  *)
+    IMAGE_TAG="latest"
+    log "Unknown architecture '$ARCH'; defaulting to multi-arch 'latest' tag."
+    ;;
+esac
+IMAGE="ghcr.io/elcanotek/victoria-terminal:${IMAGE_TAG}"
+log "Using container image $IMAGE"
+
+SHELL_NAME="${SHELL##*/}"
+case "$SHELL_NAME" in
+  zsh)
+    PROFILE_FILE="${ZDOTDIR:-$HOME}/.zshrc"
+    ;;
+  bash)
+    PROFILE_FILE="$HOME/.bashrc"
+    ;;
+  *)
+    if [ -f "$HOME/.bashrc" ]; then
+      PROFILE_FILE="$HOME/.bashrc"
+    else
+      PROFILE_FILE="$HOME/.profile"
+    fi
+    ;;
+esac
+
+touch "$PROFILE_FILE"
+log "Updating shell profile at $PROFILE_FILE"
+
+MARKER_BEGIN="# >>> victoria-terminal helper >>>"
+MARKER_END="# <<< victoria-terminal helper <<<"
+
+TEMP_FILE=$(mktemp)
+awk -v begin="$MARKER_BEGIN" -v end="$MARKER_END" '
+  $0 == begin {in_block=1; next}
+  $0 == end {in_block=0; next}
+  !in_block {print}
+' "$PROFILE_FILE" >"$TEMP_FILE"
+
+mv "$TEMP_FILE" "$PROFILE_FILE"
+
+cat <<'BLOCK' >>"$PROFILE_FILE"
+
+# >>> victoria-terminal helper >>>
+victoria() {
+  local image="IMAGE_PLACEHOLDER"
+  if ! podman pull "$image"; then
+    printf 'Victoria setup: unable to pull %s. Make sure Podman is running (start `podman machine` if applicable).\n' "$image" >&2
+    return $?
+  fi
+  podman run --rm -it \
+    -v "$HOME/Victoria:/root/Victoria" \
+    "$image" "$@"
+}
+# <<< victoria-terminal helper <<<
+BLOCK
+
+# Replace placeholder with actual image in the profile block.
+sed -i "" -e "s|IMAGE_PLACEHOLDER|$IMAGE|" "$PROFILE_FILE" 2>/dev/null || \
+  sed -i -e "s|IMAGE_PLACEHOLDER|$IMAGE|" "$PROFILE_FILE"
+
+log "Added 'victoria' function to $PROFILE_FILE"
+
+log "Pulling the latest container image (this may take a moment)..."
+if ! podman pull "$IMAGE"; then
+  log "Pull failed. Start Podman (or 'podman machine start' on macOS/Windows) and run 'victoria' later to finish the download."
+fi
+
+log "All set! Restart your shell or run 'source $PROFILE_FILE', then launch Victoria with: victoria"


### PR DESCRIPTION
## Summary
- detect the Podman host architecture via `podman info` in the helper scripts with a uname/.NET fallback
- warn when an unknown architecture is detected and default to the multi-arch tag
- document the helper scripts’ architecture-aware behavior in the README helper description
- clarify in the README that running the helper lets users launch Victoria by typing `victoria`
- simplify the helper scripts to always target the default profile and remove the optional launch switches, updating the README accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb5364d4588332821eef3aec8a8ac2