### PR TITLE
docs: require podman for all installation streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Victoria supports three installation flows depending on how much automation you 
 
 ### Before you begin
 
-All Podman-based streams (1 and 2) require a working Podman installation.
+Victoria requires a working Podman installation for every stream. Install and validate Podman before continuing with any setup path.
 
 1. **Install Podman** from [podman.io](https://podman.io) or your operating system's package manager.
 2. **Verify Podman works** by running `podman --version`. If you see a version number, you're ready to go.


### PR DESCRIPTION
## Summary
- clarify that Podman must be installed before following any installation stream in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc0d93025c83328edc6a8e3419998b