### PR TITLE
[Installer] Rework Windows helper instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,37 @@ Let Victoria wire up the remaining pieces for you. The helper scripts validate t
   curl -fsSL https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.sh | bash
   ```
 * **Windows (PowerShell)**
-  ```powershell
-  irm https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1 | iex
-  ```
 
-> [!NOTE]
-> If PowerShell warns about running an unsigned script, launch it once with a temporary bypass:
-> ```powershell
-> pwsh -NoProfile -ExecutionPolicy Bypass -Command "& { irm 'https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1' | iex }"
-> ```
+  **Quick method – run the helper directly**
+
+  1. Open PowerShell or Terminal (preferably as an administrator).
+  2. Paste the command below to download and run the script in one step:
+
+     ```powershell
+     & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1')))
+     ```
+
+  > [!NOTE]
+  > If PowerShell warns about running an unsigned script, temporarily bypass the policy for the current session:
+  > ```powershell
+  > powershell -NoProfile -ExecutionPolicy Bypass -Command "& { & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1'))) }"
+  > ```
+  > Swap `powershell` for `pwsh` when PowerShell 7+ is installed.
+
+  **Traditional method – download first, run locally**
+
+  1. Download the installer script to a folder of your choice:
+
+     ```powershell
+     Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1' -OutFile '.\install_victoria.ps1'
+     ```
+  2. (Optional) Review the script in your editor.
+  3. Run it from PowerShell:
+
+     ```powershell
+     Set-ExecutionPolicy Bypass -Scope Process -Force
+     .\install_victoria.ps1
+     ```
 
 After the helper finishes, open a new terminal session (or reload your profile with `source ~/.bashrc`, `source ~/.zshrc`, or `. $PROFILE`) and start Victoria with a single command:
 

--- a/install_victoria.ps1
+++ b/install_victoria.ps1
@@ -1,4 +1,10 @@
 #!/usr/bin/env pwsh
+param(
+    [switch] $Help,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]] $ExtraArgs
+)
+
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
@@ -15,12 +21,6 @@ This helper validates Podman, prepares the shared Victoria workspace, and
 installs a reusable `victoria` command in your PowerShell profile.
 '@
 }
-
-param(
-    [switch] $Help,
-    [Parameter(ValueFromRemainingArguments = $true)]
-    [string[]] $ExtraArgs
-)
 
 if ($Help) {
     Show-Help


### PR DESCRIPTION
## Summary
- restructure the Windows helper section in the README to mirror the quick/traditional PowerShell guidance pattern
- document the scriptblock-based quick command plus manual download instructions and updated execution policy bypass example

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cc541def608332a5bef47b7ee9549b