### PR TITLE
[VictoriaTerminal] Handle null ExtraArgs in installer

### DIFF
--- a/install_victoria.ps1
+++ b/install_victoria.ps1
@@ -27,6 +27,10 @@ if ($Help) {
     exit 0
 }
 
+if ($null -eq $ExtraArgs) {
+    $ExtraArgs = @()
+}
+
 if ($ExtraArgs.Count -gt 0) {
     Write-Error "This script does not accept arguments."
     Show-Help


### PR DESCRIPTION
## Summary
- guard against null ExtraArgs when running the installer script from a remote invocation
- ensure the argument validation still triggers when unexpected parameters are supplied

## Testing
- not run (PowerShell not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68cc5d328ffc8332a8584d765c896886