### PR TITLE
Fix quoting in profile warning message

### DIFF
--- a/install_victoria.ps1
+++ b/install_victoria.ps1
@@ -117,7 +117,7 @@ $functionBlockLines = @(
     '    )',
     "    & podman pull $image",
     '    if ($LASTEXITCODE -ne 0) {',
-    "        Write-Warning \"Victoria setup: unable to pull $image. Make sure Podman is running (start 'podman machine' if applicable).\"",
+    "        Write-Warning `"Victoria setup: unable to pull $image. Make sure Podman is running (start 'podman machine' if applicable).`"",
     '        return',
     '    }',
     '    & podman run --rm -it `',


### PR DESCRIPTION
## Summary
- fix improper escaping in the profile helper's Write-Warning line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68cc629b2990833296a24d56da5cecc9