### PR TITLE
[Docs] Simplify Windows helper instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,37 +49,9 @@ Let Victoria wire up the remaining pieces for you. The helper scripts validate t
   curl -fsSL https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.sh | bash
   ```
 * **Windows (PowerShell)**
-
-  **Quick method – run the helper directly**
-
-  1. Open PowerShell or Terminal (preferably as an administrator).
-  2. Paste the command below to download and run the script in one step:
-
-     ```powershell
-     & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1')))
-     ```
-
-  > [!NOTE]
-  > If PowerShell warns about running an unsigned script, temporarily bypass the policy for the current session:
-  > ```powershell
-  > powershell -NoProfile -ExecutionPolicy Bypass -Command "& { & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1'))) }"
-  > ```
-  > Swap `powershell` for `pwsh` when PowerShell 7+ is installed.
-
-  **Traditional method – download first, run locally**
-
-  1. Download the installer script to a folder of your choice:
-
-     ```powershell
-     Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1' -OutFile '.\install_victoria.ps1'
-     ```
-  2. (Optional) Review the script in your editor.
-  3. Run it from PowerShell:
-
-     ```powershell
-     Set-ExecutionPolicy Bypass -Scope Process -Force
-     .\install_victoria.ps1
-     ```
+  ```powershell
+  & ([scriptblock]::Create((irm 'https://raw.githubusercontent.com/ElcanoTek/victoria-terminal/main/install_victoria.ps1')))
+  ```
 
 After the helper finishes, open a new terminal session (or reload your profile with `source ~/.bashrc`, `source ~/.zshrc`, or `. $PROFILE`) and start Victoria with a single command:
 


### PR DESCRIPTION
## Summary
- streamline the README's Windows helper section to a single one-line command that mirrors the macOS/Linux instructions

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cc78ae277c8332bb7bb2690fca8011