### PR TITLE
[Docs] Add README badges and contact info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Victoria Terminal
 
-<img src="assets/VictoriaTerminal.png" alt="Victoria Icon" width="200" />
+[![CI](https://github.com/ElcanoTek/victoria-terminal/actions/workflows/ci.yml/badge.svg)](https://github.com/ElcanoTek/victoria-terminal/actions/workflows/ci.yml)
+[![Container Image](https://github.com/ElcanoTek/victoria-terminal/actions/workflows/container-image.yml/badge.svg)](https://github.com/ElcanoTek/victoria-terminal/actions/workflows/container-image.yml)
+[![License: Elastic License 2.0](https://img.shields.io/badge/license-Elastic%20License%202.0-blue.svg)](LICENSE)
+[![Contact](https://img.shields.io/badge/contact-brad%40elcanotek.com-informational.svg)](mailto:brad@elcanotek.com)
 
 ![Victoria Terminal Demo](assets/victoria.gif)
 


### PR DESCRIPTION
## Summary
- remove the standalone Victoria icon from the README header
- add build, container image, license, and contact badges to the README

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cd3078b9b483328833c83c99bb6018