### PR TITLE
Adopt Business Source License

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,64 @@
+# ElcanoTek Contributor License Agreement (CLA)
+
+Effective Date: 2025-02-14
+
+Thank you for your interest in contributing to Victoria Terminal (the "Project"). This Contributor License Agreement (the "Agreement") describes the terms under which you (the "Contributor") make intellectual property available to ElcanoTek ("ElcanoTek," "we," or "us"). By submitting a Contribution to the Project, you agree to the terms of this Agreement.
+
+## 1. Definitions
+
+- **Contribution** means any source code, object code, documentation, data, fixes, designs, text, artwork, configuration, or other material that you intentionally submit to the Project in any form.
+- **Submit** means sending a Contribution to the Project by any means, including by GitHub pull request, GitHub issue, code review tool, email, or any other communication channel that is used to discuss or manage the Project.
+- **Contribution Materials** means the Contribution and any related intellectual property, including any patent claims, copyrights, trade secrets, trademarks, and other rights in such Contribution.
+
+## 2. Your License Grant to ElcanoTek
+
+You hereby grant to ElcanoTek, and ElcanoTek's affiliates, successors, and assigns, a perpetual, worldwide, non-exclusive, transferable, sublicensable, irrevocable, royalty-free license to:
+
+1. use, reproduce, publicly perform, publicly display, make, have made, offer to sell, sell, import, export, distribute, and otherwise exploit the Contribution Materials for any purpose;
+2. create, have created, and exploit derivative works of the Contribution Materials; and
+3. relicense and sublicense the Contribution Materials and derivative works under any terms ElcanoTek chooses, including proprietary licenses.
+
+ElcanoTek may exercise the rights granted in this Section 2 in any media now known or later developed. This license grant includes the right to combine the Contribution Materials with any other materials and to distribute the resulting works under any license of ElcanoTek's choosing.
+
+## 3. Moral Rights
+
+To the maximum extent permitted by applicable law, you waive, and agree not to assert, any moral rights or similar rights you may have in the Contribution Materials against ElcanoTek or its licensees.
+
+## 4. Patent License
+
+You grant to ElcanoTek a perpetual, worldwide, non-exclusive, transferable, sublicensable, irrevocable, royalty-free patent license to make, have made, use, sell, offer to sell, import, and otherwise transfer the Contribution Materials, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contribution alone or by combination of your Contribution with the Project.
+
+## 5. Representations and Warranties
+
+You represent and warrant that:
+
+- You are legally entitled to grant the licenses described in this Agreement.
+- Each Contribution is an original work of authorship authored by you, or, if not, that you have secured all necessary permissions to submit the Contribution and grant the licenses set forth herein.
+- Your Contribution does not and will not violate any third-party rights or any applicable laws.
+- You have the full authority to enter into this Agreement on behalf of yourself and, if applicable, your employer or other entity that has rights to the Contribution Materials.
+
+If your employer or another entity has intellectual property rights to the Contribution, you represent that you are authorized to submit the Contribution on their behalf and that they have waived or granted to you the necessary rights for you to submit the Contribution and to grant the licenses stated in this Agreement.
+
+## 6. No Obligation to Use
+
+ElcanoTek is not obligated to use, merge, publish, or otherwise incorporate your Contribution into the Project. ElcanoTek may decide to reject, remove, or modify any Contribution at its sole discretion.
+
+## 7. Disclaimer
+
+You provide the Contribution Materials "as-is" without warranties or conditions of any kind, either express or implied, including, without limitation, any implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement. You are not required to provide support for your Contribution.
+
+## 8. Governing Law
+
+This Agreement is governed by and construed in accordance with the laws of the State of Texas, excluding its conflict-of-law rules. You consent to the personal jurisdiction and venue of the state and federal courts located in Travis County, Texas for any disputes arising out of or relating to this Agreement.
+
+## 9. Entire Agreement
+
+This Agreement constitutes the entire agreement between you and ElcanoTek concerning the subject matter described herein and supersedes all prior agreements and understandings between the parties with respect to that subject matter. This Agreement may be updated by ElcanoTek from time to time by posting a revised version in this repository. Continued submission of Contributions after the effective date of any update constitutes acceptance of the updated Agreement.
+
+## 10. Acceptance
+
+By Submitting a Contribution to the Project, you acknowledge that you have read and understood this Agreement and agree to be bound by its terms. If you do not agree to the terms of this Agreement, do not Submit a Contribution to the Project.
+
+---
+
+If you have questions about this Agreement, please contact cla@elcanotek.com.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,10 @@ First off, thank you for considering contributing to Victoria! We welcome all co
 
 This document provides guidelines for developers who want to contribute to the project.
 
+## Contributor License Agreement
+
+By submitting a Contribution you agree to the terms of the [ElcanoTek Contributor License Agreement](CLA.md). The CLA grants ElcanoTek a perpetual, worldwide right to use, modify, commercialize, and relicense your Contribution in any manner. If you do not agree to those terms, do not submit Contributions.
+
 ## Development Environment
 
 Victoria is distributed as a container image and contributors are encouraged to

--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,61 @@
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
 
-Copyright (c) 2025 ElcanoTek
+Parameters
 
-## Proprietary License
+Licensor:             ElcanoTek
+Licensed Work:        Victoria Terminal. The Licensed Work is (c) 2025 ElcanoTek.
+Additional Use Grant: You may make non-production use of the Licensed Work, including
+                      evaluation, internal testing, development, and submitting
+                      contributions back to the Licensed Work. No production use is
+                      permitted without a commercial license from the Licensor.
+Change Date:          2028-01-01
+Change License:       Apache License 2.0
 
-This software is proprietary. The source code is made publicly available for the purposes of transparency, security auditing, and evaluation. A valid commercial license from ElcanoTek is required for any use of this software beyond the limited exceptions listed below.
+For information about alternative licensing arrangements for the Licensed Work,
+please contact brad@elcanotek.com.
 
-### Permitted Exceptions
+Notice
 
-Without a commercial license, you are granted a limited right to:
+Business Source License 1.1
 
-*   Read, review, and analyze the source code for security and evaluation purposes.
-*   Compile and run the software on a temporary basis for evaluation, for a period not to exceed 30 days.
-*   Fork the repository and submit pull requests for bug fixes or improvements. Any voluntary contributions you provide will become the property of ElcanoTek and remain subject to this license.
+Terms
 
-### Prohibited Actions
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited production use.
 
-Without a valid commercial license from ElcanoTek, you are expressly forbidden to:
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
+the terms of the Change License, and the rights granted in the paragraph
+above terminate.
 
-*   Use the software for any internal business, production, or commercial purposes.
-*   Use the software for any personal projects or non-commercial activities beyond the 30-day evaluation period.
-*   Distribute, sublicense, or embed the software in any other application.
-*   Remove or obscure this license agreement or any copyright notices.
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
 
-### Commercial License
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may vary
+for each version of the Licensed Work released by Licensor.
 
-To obtain a commercial license, please contact ElcanoTek at brad@elcanotek.com.
+You must conspicuously display this License on each original or modified copy
+of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
 
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/ElcanoTek/victoria-terminal/actions/workflows/ci.yml/badge.svg)](https://github.com/ElcanoTek/victoria-terminal/actions/workflows/ci.yml)
 [![Container Image](https://github.com/ElcanoTek/victoria-terminal/actions/workflows/container-image.yml/badge.svg)](https://github.com/ElcanoTek/victoria-terminal/actions/workflows/container-image.yml)
-[![License: Proprietary](https://img.shields.io/badge/license-Proprietary-red.svg)](LICENSE)  
+[![License: BUSL-1.1](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)](LICENSE)
 [![Contact](https://img.shields.io/badge/contact-brad%40elcanotek.com-informational.svg)](mailto:brad@elcanotek.com)
 
 <img src="assets/victoria.gif" alt="Victoria Terminal Demo" width="650">
@@ -16,7 +16,8 @@ Victoria is Elcano's AI agent for navigating programmatic advertising datasets. 
 - **Container-first distribution.** Victoria ships as a Podman image that packages Python, the `crush` CLI, and all dependencies. Running in a container isolates the agent from the host OS while still allowing controlled file sharing via `~/Victoria`.
 - **Secrets stay in your workspace.** Credentials are written to `~/Victoria/.env`, mounted into the container at runtime. The container's default command can regenerate or update this file without embedding secrets in the image.
 - **Transparent builds.** GitHub Actions automatically builds and publishes the container to `ghcr.io/elcanotek/victoria-terminal`, ensuring every release is reproducible and verified in CI.
-- **Publicly-visible source code.** The repository is publicly available for review and evaluation. All usage is subject to the proprietary license. See [LICENSE](LICENSE) for details.
+- **Publicly-visible source code.** The repository is publicly available for review and evaluation. All usage is subject to the Victoria Terminal Business Source License (BUSL-1.1), a source-available license. See [LICENSE](LICENSE) for details.
+- **Contributor license agreement.** Submitting a patch, issue, or other material constitutes acceptance of the [ElcanoTek Contributor License Agreement](CLA.md), which grants ElcanoTek full rights to use, commercialize, and relicense all Contributions.
 
 
 ## 🛠️ Prerequisites
@@ -118,7 +119,7 @@ podman run --rm -it \
 ```
 
 > [!IMPORTANT]
-> Non-interactive runs that skip the launch banner must pass `--acccept-license` (for example, together with `--no-banner`). Using this flag automatically accepts the Victoria Terminal license as detailed in [LICENSE](LICENSE).
+> Non-interactive runs that skip the launch banner must pass `--acccept-license` (for example, together with `--no-banner`). Using this flag automatically accepts the Victoria Terminal Business Source License described in [LICENSE](LICENSE).
 
 Windows users should keep the commands on a single line and use `$env:USERPROFILE/Victoria` in place of `~/Victoria`.
 


### PR DESCRIPTION
## Summary
- replace the proprietary license text with the Business Source License (BUSL-1.1) tailored for Victoria Terminal
- update README references to highlight the Business Source License as the project's source-available licensing model
- add an ElcanoTek Contributor License Agreement and reference it in the README and contributing guide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ce9728f3048332bbff7053f9a5cf72