### PR TITLE
docs: add victoria license header guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ To run the tests:
 - Use `isort` for import sorting.
 - Use type hints for all function signatures.
 - Use `rich` for all terminal output.
+- **License Notes (Python):** When editing any `.py` file that includes a `License Notes: YYYY-MM-DD` line in its header comment, update that date to match the day of your change (ISO `YYYY-MM-DD`).
+- **Victoria manifest header:** Ensure `VICTORIA.md` begins with the standard license header comment block. Whenever you edit `VICTORIA.md`, refresh the `License Notes` line in that header to the current edit date (ISO `YYYY-MM-DD`).
 
 ## Data Analysis Principles
 

--- a/VICTORIA.md
+++ b/VICTORIA.md
@@ -1,3 +1,20 @@
+<!--
+Copyright (c) 2025 ElcanoTek
+
+This file is part of Victoria Terminal.
+
+This software is licensed under the Business Source License 1.1.
+You may not use this file except in compliance with the license.
+You may obtain a copy of the license at
+
+    https://github.com/ElcanoTek/victoria-terminal/blob/main/LICENSE
+
+Change Date: 2027-09-20
+Change License: GNU General Public License v3.0 or later
+
+License Notes: Updated 2025-09-20
+-->
+
 # Victoria — Elcano's AI Navigator for Programmatic Excellence
 
 > **Prime Directive (Non‑Negotiable):** When computing any ratio metric (CPC, CTR, CVR, VCR, Viewability, etc.), **aggregate numerators and denominators first**, then divide. **Never filter out rows where the denominator is zero** (e.g., `clicks = 0`) unless explicitly instructed; instead use *safe division* (e.g., `NULLIF`, `TRY_DIVIDE`) so totals remain correct. Report "N/A" when the denominator is zero.


### PR DESCRIPTION
## Summary
- clarify the License Notes expectations for Python headers and add instructions for maintaining the Victoria manifest header
- prepend the standard license header comment block to `VICTORIA.md` with current License Notes metadata

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cea8243dbc833295875db30a7d5b3a