### PR TITLE
[Container] Allow overriding entrypoint command

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,6 +18,8 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 COPY . .
 
 RUN mkdir -p /root/.local/share/crush \
-    && cp configs/crush/crush.local.json /root/.local/share/crush/crush.json
+    && cp configs/crush/crush.local.json /root/.local/share/crush/crush.json \
+    && install -Dm755 container_entrypoint.sh /usr/local/bin/container-entrypoint.sh
 
+ENTRYPOINT ["/usr/local/bin/container-entrypoint.sh"]
 CMD ["python3", "/workspace/victoria_terminal.py"]

--- a/container_entrypoint.sh
+++ b/container_entrypoint.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_CMD=("python3" "/workspace/victoria_terminal.py")
+
+# If no arguments were provided, launch Victoria.
+if [[ $# -eq 0 ]]; then
+    exec "${DEFAULT_CMD[@]}"
+fi
+
+# Handle a bare `--` that may be used to separate Podman options.
+if [[ "$1" == "--" ]]; then
+    shift
+fi
+
+# If nothing remains after stripping `--`, fall back to Victoria.
+if [[ $# -eq 0 ]]; then
+    exec "${DEFAULT_CMD[@]}"
+fi
+
+# Treat leading flags as arguments for Victoria.
+if [[ "$1" == -* ]]; then
+    exec "${DEFAULT_CMD[@]}" "$@"
+fi
+
+# If the first argument is an executable on PATH, run it directly. This allows
+# commands such as `podman run … bash` to spawn an interactive shell.
+if command -v "$1" >/dev/null 2>&1; then
+    exec "$@"
+fi
+
+# Fallback: run Victoria with the provided arguments.
+exec "${DEFAULT_CMD[@]}" "$@"


### PR DESCRIPTION
## Summary
- add a container entrypoint script that forwards flag-style arguments to victoria_terminal.py while allowing other commands to run normally
- update the Containerfile to install the entrypoint script and keep victoria_terminal.py as the default command

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1d43c8a5883328f0d5a12713efc80