### PR TITLE
Improve container argument passing best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,26 +102,38 @@ Use the table below to pull (or update) the matching image and run it. Re-runnin
 > [!NOTE]
 > The run commands are shown on a single line to work in PowerShell and other shells without additional escaping. On macOS and Linux you can add `\` line continuations if you prefer.
 
-On macOS and Linux you can split the run command across multiple lines for readability (the example below shows the `x86_64` tag; swap in the tag from the table above if you are on Arm64):
+#### Best Practices for Argument Passing
+
+When passing arguments to Victoria inside the container, always use the `--` separator to clearly distinguish between container options and application arguments:
 
 ```bash
-podman run --rm -it \
-  -v ~/Victoria:/root/Victoria \
-  ghcr.io/elcanotek/victoria-terminal:latest
+# Correct: Arguments after -- go to Victoria
+podman run --rm -it -v ~/Victoria:/root/Victoria ghcr.io/elcanotek/victoria-terminal:latest -- --reconfigure --skip-launch
+
+# Avoid: Ambiguous argument parsing
+podman run --rm -it -v ~/Victoria:/root/Victoria ghcr.io/elcanotek/victoria-terminal:latest --reconfigure --skip-launch
 ```
 
-To pass command-line options directly to the container's default command (`victoria_terminal.py`), append them after the image name with a literal `--` separator.
+The `--` separator ensures that:
+- Container runtime options (like `--rm`, `-it`, `-v`) are processed by Podman
+- Application arguments (like `--reconfigure`, `--skip-launch`) are passed to Victoria
+- No confusion occurs between container and application flags
+
+On macOS and Linux you can split the run command across multiple lines for readability (the example below shows the `x86_64` tag; swap in the tag from the table above if you are on Arm64):
 
 ```bash
 podman run --rm -it \
   -v ~/Victoria:/root/Victoria \
   ghcr.io/elcanotek/victoria-terminal:latest -- --reconfigure --skip-launch
 ```
-
 > [!IMPORTANT]
-> Non-interactive runs that skip the launch banner must pass `--acccept-license` (for example, together with `--no-banner`). Using this flag automatically accepts the Victoria Terminal Business Source License described in [LICENSE](LICENSE).
+> Non-interactive runs that skip the launch banner must pass `--accept-license` (for example, together with `--no-banner`). Using this flag automatically accepts the Victoria Terminal Business Source License described in [LICENSE](LICENSE).
 
-Windows users should keep the commands on a single line and use `$env:USERPROFILE/Victoria` in place of `~/Victoria`.
+Windows users should keep the commands on a single line and use `$env:USERPROFILE/Victoria` in place of `~/Victoria`:
+
+```powershell
+podman run --rm -it -v "$env:USERPROFILE/Victoria:/root/Victoria" ghcr.io/elcanotek/victoria-terminal:latest -- --reconfigure --skip-launch
+```
 
 #### Configure on first run
 
@@ -197,4 +209,3 @@ Every push to `main` triggers a GitHub Actions workflow that rebuilds the Podman
 ## 🤝 Contributing
 
 We welcome contributions to Victoria! Review our [Contributing Guidelines](CONTRIBUTING.md) for code style, testing expectations, and the pull-request process.
-

--- a/container_entrypoint.sh
+++ b/container_entrypoint.sh
@@ -8,7 +8,10 @@ if [[ $# -eq 0 ]]; then
     exec "${DEFAULT_CMD[@]}"
 fi
 
-# Handle a bare `--` that may be used to separate Podman options.
+# Handle a bare `--` separator used to distinguish container options from application arguments.
+# This follows standard Unix conventions where `--` signals the end of options processing.
+# Using `--` is the recommended way to pass arguments to Victoria to avoid confusion
+# between Podman container options and Victoria application flags.
 if [[ "$1" == "--" ]]; then
     shift
 fi


### PR DESCRIPTION
## Summary

This PR improves the container argument passing documentation and implementation to follow Podman/Docker best practices for argument separation.

## Changes Made

### Documentation Improvements (README.md)
- **Added Best Practices section** explaining the purpose and usage of the `--` separator
- **Standardized all examples** to consistently use `--` when passing application arguments
- **Updated Windows PowerShell examples** to follow the same pattern as Unix examples
- **Fixed typo**: `--acccept-license` → `--accept-license`
- **Enhanced clarity** of command examples with better formatting

### Code Improvements (container_entrypoint.sh)
- **Enhanced comments** explaining the `--` separator handling
- **Added context** about Unix conventions and best practices
- **Improved readability** of the argument processing logic

## Why These Changes Matter

1. **Prevents argument confusion**: Without the `--` separator, users might accidentally pass container flags to the application or vice versa
2. **Follows standard conventions**: The `--` separator is a well-established Unix/Linux convention for separating command options from arguments
3. **Improves user experience**: Clear, consistent documentation reduces confusion and support requests
4. **Maintains compatibility**: All existing functionality continues to work as before

## Examples

**Before (ambiguous):**
```bash
podman run --rm -it -v ~/Victoria:/root/Victoria image:tag --reconfigure --skip-launch
```

**After (clear):**
```bash
podman run --rm -it -v ~/Victoria:/root/Victoria image:tag -- --reconfigure --skip-launch
```

The `--` separator ensures that:
- Container runtime options (`--rm`, `-it`, `-v`) are processed by Podman
- Application arguments (`--reconfigure`, `--skip-launch`) are passed to Victoria
- No confusion occurs between container and application flags

## Testing

- [x] All existing examples in the README work correctly
- [x] The entrypoint script properly handles the `--` separator (existing functionality)
- [x] Windows PowerShell examples follow the same pattern as Unix examples
- [x] Documentation is consistent across all installation streams

This is a documentation and clarity improvement that doesn't change any existing functionality.