### PR TITLE
[VictoriaTerminal] Resolve license via resource path

### DIFF
--- a/tests/test_victoria_terminal.py
+++ b/tests/test_victoria_terminal.py
@@ -199,9 +199,7 @@ def test_resolve_license_path_uses_resource_bundle(
     assert entrypoint._resolve_license_path() == license_file
 
 
-def test_resolve_license_path_prefers_env_override(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_resolve_license_path_prefers_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     env_license = tmp_path / "custom-license.txt"
     env_license.write_text("terms", encoding="utf-8")
     monkeypatch.setenv("VICTORIA_LICENSE_PATH", str(env_license))


### PR DESCRIPTION
## Summary
- replace the candidate search logic with a direct resource-based license lookup that still honours the VICTORIA_LICENSE_PATH override
- raise a precise error when the bundled license is missing
- cover the new resolution helper with targeted unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d3fdc96f4c8332b7959d6c7571970a