### PR TITLE
[VictoriaTerminal] Resolve Gamma MCP template paths

### DIFF
--- a/configs/crush/crush.template.json
+++ b/configs/crush/crush.template.json
@@ -100,12 +100,12 @@
       "type": "stdio",
       "command": "python3",
       "args": [
-        "gamma-mcp.py"
+        "${GAMMA_MCP_SCRIPT}"
       ],
-      "cwd": "${VICTORIA_HOME}",
+      "cwd": "${GAMMA_MCP_DIR}",
       "env": {
         "GAMMA_API_KEY": "${GAMMA_API_KEY}",
-        "PYTHONPATH": "${VICTORIA_HOME}"
+        "PYTHONPATH": "${GAMMA_MCP_DIR}"
       }
     }
   }


### PR DESCRIPTION
## Summary
- update the Crush gamma MCP template to reference placeholders for the bundled script path and directory
- fill those placeholders during Crush config generation so the Gamma server runs from the packaged location while keeping env substitution intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d407e03df08332a9e450b5451ee9f9