### PR TITLE
fix(Containerfile): Suppress pip root user warning

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,8 @@ ARG USER_GID=${USER_UID}
 ENV PATH="/home/${USERNAME}/.local/bin:/root/.local/bin:${PATH}" \
     PYTHONUNBUFFERED="1" \
     GOTOOLCHAIN="auto" \
-    GOSUMDB="sum.golang.org"
+    GOSUMDB="sum.golang.org" \
+    PIP_ROOT_USER_ACTION="ignore"
 
 RUN dnf -y upgrade && \
     dnf -y install python3 python3-pip git curl golang helix uv shadow-utils && \


### PR DESCRIPTION
The pip install command in the Containerfile was showing a warning about running as the root user. This is expected in a container build, so the warning can be safely ignored.

This change adds the `PIP_ROOT_USER_ACTION=ignore` environment variable to the Containerfile to suppress this warning.

## Summary
- _Replace this line with a summary of your changes_

## Testing
- [ ] `pytest`
- [ ] other (please describe)

## Checklist
- [ ] Documentation updated (if needed)
- [ ] Tests added or updated (if needed)
- [ ] Ready for review
