### PR TITLE
Docs: Add SELinux flag and remove specific notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Victoria is distributed as a container image. Build and run that image locally d
      --security-opt=no-new-privileges \
      --cap-drop=all \
      -e VICTORIA_HOME=/workspace/Victoria \
-     -v ~/Victoria:/workspace/Victoria \
+     -v ~/Victoria:/workspace/Victoria:z \
      victoria-terminal
    ```
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Use the table below to pull (or update) the matching image and run it. Re-runnin
 
 | Platform | CPU architecture | Pull / update | Run |
 | --- | --- | --- | --- |
-| macOS or Linux (Intel/AMD) | `x86_64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest` | `podman run --rm -it --userns=keep-id --security-opt=no-new-privileges --cap-drop=all -e VICTORIA_HOME=/workspace/Victoria -v ~/Victoria:/workspace/Victoria ghcr.io/elcanotek/victoria-terminal:latest` |
-| macOS or Linux (Arm64) | `arm64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest-arm64` | `podman run --rm -it --userns=keep-id --security-opt=no-new-privileges --cap-drop=all -e VICTORIA_HOME=/workspace/Victoria -v ~/Victoria:/workspace/Victoria ghcr.io/elcanotek/victoria-terminal:latest-arm64` |
+| macOS or Linux (Intel/AMD) | `x86_64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest` | `podman run --rm -it --userns=keep-id --security-opt=no-new-privileges --cap-drop=all -e VICTORIA_HOME=/workspace/Victoria -v ~/Victoria:/workspace/Victoria:z ghcr.io/elcanotek/victoria-terminal:latest` |
+| macOS or Linux (Arm64) | `arm64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest-arm64` | `podman run --rm -it --userns=keep-id --security-opt=no-new-privileges --cap-drop=all -e VICTORIA_HOME=/workspace/Victoria -v ~/Victoria:/workspace/Victoria:z ghcr.io/elcanotek/victoria-terminal:latest-arm64` |
 | Windows PowerShell (Intel/AMD) | `x86_64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest` | `podman run --rm -it -e VICTORIA_HOME=/workspace/Victoria -v "$env:USERPROFILE/Victoria:/workspace/Victoria" ghcr.io/elcanotek/victoria-terminal:latest` |
 | Windows PowerShell (Arm64) | `arm64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest-arm64` | `podman run --rm -it -e VICTORIA_HOME=/workspace/Victoria -v "$env:USERPROFILE/Victoria:/workspace/Victoria" ghcr.io/elcanotek/victoria-terminal:latest-arm64` |
 

--- a/install_victoria.sh
+++ b/install_victoria.sh
@@ -116,7 +116,7 @@ victoria() {
     --security-opt=no-new-privileges \
     --cap-drop=all \
     -e VICTORIA_HOME=/workspace/Victoria \
-    -v "$HOME/Victoria:/workspace/Victoria" \
+    -v "$HOME/Victoria:/workspace/Victoria:z" \
     "$image" "$@"
 }
 # <<< victoria-terminal helper <<<


### PR DESCRIPTION
This commit adds the `:z` flag to the `podman run` commands in `CONTRIBUTING.md`, `README.md`, and `install_victoria.sh`. This ensures that the volume mount will work correctly on systems with SELinux enabled, while being safely ignored on systems without it, like macOS.

The now-redundant explanatory notes for SELinux have been removed from `CONTRIBUTING.md` and `README.md` to simplify the documentation.

## Summary
- _Replace this line with a summary of your changes_

## Testing
- [ ] `pytest`
- [ ] other (please describe)

## Checklist
- [ ] Documentation updated (if needed)
- [ ] Tests added or updated (if needed)
- [ ] Ready for review
