### PR TITLE
Docs: streamline README and expand contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,15 +9,113 @@ By submitting a contribution you agree to the [ElcanoTek Contributor License Agr
 ## Required Tooling
 
 - **Git** for version control.
-- **Podman** for running the development container. Install Podman Desktop on macOS or Windows from [podman.io](https://podman.io) or use your Linux distribution packages. Confirm your installation with `podman --version`.
+- **Podman** for running either the published containers or the development image. Install Podman Desktop on macOS or Windows from [podman.io](https://podman.io) or use your Linux distribution packages. Confirm your installation with `podman --version`.
 
 > **Windows line endings**
 > Podman runs shell scripts from this repository. Configure Git with `git config --global core.autocrlf false` before cloning so scripts keep Unix line endings. If you already cloned the repository, run `git reset --hard` after changing the setting or use Windows Subsystem for Linux (WSL).
 
-## Prepare Your Workspace
+## Run pre-built images
+
+Use this path when you want to run the latest Victoria release without building the container yourself.
+
+### 1. Create the shared workspace
+
+Victoria stores configuration and credentials in a folder that is mounted into the container. Create it once and reuse it for every upgrade.
+
+- **macOS / Linux**
+  ```bash
+  mkdir -p ~/Victoria
+  ```
+- **Windows (PowerShell)**
+  ```powershell
+  New-Item -ItemType Directory -Path "$env:USERPROFILE/Victoria" -Force
+  ```
+- **Windows (Command Prompt)**
+  ```cmd
+  mkdir %USERPROFILE%\Victoria
+  ```
+
+### 2. Pull the correct image for your architecture
+
+Check your Podman host architecture so you can pull the matching multi-architecture image tag:
+
+```bash
+podman info --format '{{.Host.Arch}}'
+```
+
+Use the commands below to stay current with the published images. Re-running `podman pull` keeps you on the latest release.
+
+| Platform | CPU architecture | Pull / update | Run |
+| --- | --- | --- | --- |
+| macOS or Linux (Intel/AMD) | `x86_64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest` | `podman run --rm -it --userns=keep-id --security-opt=no-new-privileges --cap-drop=all -e VICTORIA_HOME=/workspace/Victoria -v ~/Victoria:/workspace/Victoria:z ghcr.io/elcanotek/victoria-terminal:latest` |
+| macOS or Linux (Arm64) | `arm64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest-arm64` | `podman run --rm -it --userns=keep-id --security-opt=no-new-privileges --cap-drop=all -e VICTORIA_HOME=/workspace/Victoria -v ~/Victoria:/workspace/Victoria:z ghcr.io/elcanotek/victoria-terminal:latest-arm64` |
+| Windows PowerShell (Intel/AMD) | `x86_64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest` | `podman run --rm -it -e VICTORIA_HOME=/workspace/Victoria -v "$env:USERPROFILE/Victoria:/workspace/Victoria" ghcr.io/elcanotek/victoria-terminal:latest` |
+| Windows PowerShell (Arm64) | `arm64` | `podman pull ghcr.io/elcanotek/victoria-terminal:latest-arm64` | `podman run --rm -it -e VICTORIA_HOME=/workspace/Victoria -v "$env:USERPROFILE/Victoria:/workspace/Victoria" ghcr.io/elcanotek/victoria-terminal:latest-arm64` |
+
+> **Tip:** The run commands are shown on a single line for PowerShell compatibility. On macOS and Linux you can add `\` line continuations for readability.
+
+When you need to pass arguments through to Victoria, include `--` after the image name so Podman stops parsing options. For example:
+
+```bash
+podman run --rm -it --userns=keep-id --security-opt=no-new-privileges --cap-drop=all -e VICTORIA_HOME=/workspace/Victoria -v ~/Victoria:/workspace/Victoria ghcr.io/elcanotek/victoria-terminal:latest -- --skip-launch
+```
+
+The same command on Windows stays on a single line and uses `$env:USERPROFILE/Victoria` for the shared folder path.
+
+> **Important:** Non-interactive runs that skip the launch banner must also pass `--accept-license` (for example, together with `--no-banner`). Using this flag automatically accepts the Victoria Terminal Business Source License described in [LICENSE](LICENSE).
+
+### 3. Configure on first run
+
+The container's default command (`victoria_terminal.py`) assumes you provide a ready-to-use `.env` file inside `~/Victoria`.
+
+- If `~/Victoria/.env` exists, Victoria loads the environment variables and launches immediately.
+- If the file is missing—or lacks a required key—it logs a warning that calls out which integrations will be unavailable until the `.env` file is updated.
+
+Victoria validates your `.env` file on every launch. Pass `--skip-launch` if you only want to perform the configuration checks without starting the UI:
+
+```bash
+podman run --rm -it \
+  --userns=keep-id \
+  --security-opt=no-new-privileges \
+  --cap-drop=all \
+  -e VICTORIA_HOME=/workspace/Victoria \
+  -v ~/Victoria:/workspace/Victoria \
+  ghcr.io/elcanotek/victoria-terminal:latest -- --skip-launch
+```
+
+You can also point the default command at an alternate shared location with `--shared-home /path/to/shared/Victoria`.
+
+#### Managing the `.env` file
+
+Victoria reads every environment variable defined in `~/Victoria/.env` and exposes it to the terminal session. Provide two artifacts to your users:
+
+1. A commented template that documents each key (use `example.env` as a starting point).
+2. A deployment-ready file with live credentials so new users can copy it into place without editing.
+
+```dotenv
+# victoria/.env (sample deployment bundle)
+OPENROUTER_API_KEY="sk-or-your-api-key-here"
+GAMMA_API_KEY="sk-gamma-your-api-key-here"
+```
+
+- Keep comments in the template to describe why a key is needed or where to request it.
+- Distribute sensitive values through secure channels—Victoria simply reads them at runtime.
+- To rotate a credential, update the `.env` file on the host and restart the container; no interactive wizard is required.
+
+Swap in the image tag that matches your architecture (from the table above) and adjust the host path syntax for your platform. Windows PowerShell users should run the command on a single line with `$env:USERPROFILE/Victoria`.
+
+#### Using local LLM providers
+
+Victoria is configured to work with local LLM providers like LM Studio. To connect to LM Studio from within the Victoria container, you must enable network access.
+
+In LM Studio, navigate to the server settings and ensure that **"Serve on local network"** is turned on. This allows the container to reach the server at `http://host.containers.internal:1234`.
+
+## Build from source
+
+Follow this path if you plan to modify Victoria, integrate it into a custom workflow, or contribute changes upstream.
 
 1. **Clone the repository** and switch into the project directory.
-2. **Create the shared host workspace**. Victoria reads configuration and writes analysis artifacts to `~/Victoria` (or `%USERPROFILE%\Victoria` on Windows):
+2. **Create the shared host workspace** if you have not already done so:
    ```bash
    mkdir -p ~/Victoria
    ```
@@ -29,8 +127,6 @@ By submitting a contribution you agree to the [ElcanoTek Contributor License Agr
    podman build -t victoria-terminal .
    ```
    Rebuild the image whenever you change dependencies or Python source files.
-
-## Running the Container
 
 Run the image you just built and mount your shared workspace. Pass arguments after `--` to execute commands inside the container.
 


### PR DESCRIPTION
## Summary
- streamline the README to focus on the installer script and direct deeper workflows to the contributor guide
- move the architecture-specific pull/run table into the contributor guide and expand instructions for running published images
- clarify contributor setup by separating pre-built image usage from building the development container

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68d57adc2730833298627ce4db33a3b1