### PR TITLE
[VictoriaTerminal] Require license acceptance for task runs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,78 @@
+name: Integration Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  container-integration:
+    name: Victoria container integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      IMAGE: ghcr.io/elcanotek/victoria-terminal:latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Ensure OPENROUTER_API_KEY secret is available
+        if: ${{ secrets.OPENROUTER_API_KEY == '' }}
+        run: |
+          echo "::error::OPENROUTER_API_KEY secret is not configured."
+          exit 1
+
+      - name: Install Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Authenticate to GitHub Container Registry
+        env:
+          GHCR_USERNAME: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "${GHCR_TOKEN}" | podman login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+
+      - name: Pull Victoria Terminal container image
+        run: podman pull "${IMAGE}"
+
+      - name: Verify crush CLI is installed
+        run: |
+          podman run --rm --network=none "${IMAGE}" crush --version
+
+      - name: Prepare Victoria home directory
+        run: mkdir -p victoria-home
+
+      - name: Run Prime Directive integration check
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        run: |
+          set +e
+          output=$(timeout 90s podman run --rm \
+            --userns=keep-id \
+            --security-opt=no-new-privileges \
+            --cap-drop=all \
+            -e OPENROUTER_API_KEY \
+            -e VICTORIA_HOME=/workspace/Victoria \
+            -v "${PWD}/victoria-home:/workspace/Victoria:Z" \
+            "${IMAGE}" \
+            -- \
+            --accept-license \
+            --task \"Explain Victoria's Prime Directive and the advertising data sources it can connect to.\")
+          status=$?
+          set -e
+
+          echo "${output}"
+
+          if [ "${status}" -ne 0 ] && [ "${status}" -ne 124 ]; then
+            echo "::error::Victoria launch exited with status ${status}" >&2
+            exit "${status}"
+          fi
+
+          if ! grep -iq "aggregate numerators and denominators first" <<<"${output}"; then
+            echo "::error::Prime Directive response was not found in victoria_terminal output" >&2
+            exit 1
+          fi
+          if ! grep -iq "Snowflake" <<<"${output}"; then
+            echo "::error::Victoria capabilities response did not mention Snowflake" >&2
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ podman run --rm -it --userns=keep-id --security-opt=no-new-privileges --cap-drop
 
 The same command on Windows stays on a single line and uses `$env:USERPROFILE/Victoria` for the shared folder path.
 
-> **Important:** Non-interactive runs that skip the launch banner must also pass `--accept-license` (for example, together with `--no-banner`). Using this flag automatically accepts the Victoria Terminal Business Source License described in [LICENSE](LICENSE).
+> **Important:** Non-interactive runs triggered with `--task` must also pass `--accept-license`. Using this flag automatically accepts the Victoria Terminal Business Source License described in [LICENSE](LICENSE).
 
 ### 3. Configure on first run
 

--- a/tests/test_victoria_terminal.py
+++ b/tests/test_victoria_terminal.py
@@ -302,16 +302,16 @@ def test_parse_args_ignores_double_dash_separator() -> None:
     assert args.skip_launch is True
 
 
-def test_parse_args_sets_no_banner_flag() -> None:
-    args = entrypoint.parse_args(["--no-banner"])
-
-    assert args.no_banner is True
-
-
 def test_parse_args_sets_accept_license_flag() -> None:
     args = entrypoint.parse_args(["--accept-license"])
 
     assert args.accept_license is True
+
+
+def test_parse_args_supports_task_flag() -> None:
+    args = entrypoint.parse_args(["--task", " Summarize mission "])
+
+    assert args.task == " Summarize mission "
 
 
 def test_main_honours_skip_launch(tmp_path: Path, mocker: pytest.MockFixture, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -336,40 +336,46 @@ def test_main_honours_skip_launch(tmp_path: Path, mocker: pytest.MockFixture, mo
     banner_sequence.assert_called_once_with()
 
 
-def test_main_skips_banner_when_flag_set(
+def test_main_task_launches_crush_without_banner(
     tmp_path: Path, mocker: pytest.MockFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.delenv("VICTORIA_HOME", raising=False)
 
     banner_sequence = mocker.patch("victoria_terminal.banner_sequence")
-    mocker.patch("victoria_terminal.ensure_app_home", side_effect=lambda path: path)
+    ensure_app_home = mocker.patch("victoria_terminal.ensure_app_home", side_effect=lambda path: path)
     mocker.patch("victoria_terminal.load_environment")
     mocker.patch("victoria_terminal.generate_crush_config")
     mocker.patch("victoria_terminal.remove_local_duckdb")
     mocker.patch("victoria_terminal.info")
     mocker.patch("victoria_terminal.preflight_crush")
-    mocker.patch("victoria_terminal.launch_crush")
+    launch_crush = mocker.patch("victoria_terminal.launch_crush")
     persist_acceptance = mocker.patch("victoria_terminal._persist_license_acceptance")
 
-    entrypoint.main(
-        [
-            "--skip-launch",
-            "--no-banner",
-            "--accept-license",
-            "--app-home",
-            str(tmp_path),
-        ]
-    )
+    entrypoint.main(["--accept-license", "--task", "Summarize Prime Directive"])
 
+    ensure_app_home.assert_called_once()
+    launch_crush.assert_called_once()
+    args, kwargs = launch_crush.call_args
+    assert kwargs["task_prompt"] == "Summarize Prime Directive"
     banner_sequence.assert_not_called()
-    persist_acceptance.assert_called_once_with(app_home=tmp_path)
+    persist_acceptance.assert_called_once()
 
 
-def test_main_no_banner_requires_license_acceptance(
-    tmp_path: Path, mocker: pytest.MockFixture, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("VICTORIA_HOME", raising=False)
+def test_main_task_rejects_conflicting_flags(mocker: pytest.MockFixture) -> None:
+    mocker.patch("victoria_terminal.ensure_app_home")
+    mocker.patch("victoria_terminal.load_environment")
+    mocker.patch("victoria_terminal.generate_crush_config")
+    mocker.patch("victoria_terminal.remove_local_duckdb")
+    mocker.patch("victoria_terminal.info")
+    mocker.patch("victoria_terminal.preflight_crush")
 
+    with pytest.raises(SystemExit) as excinfo:
+        entrypoint.main(["--task", "prompt", "--accept-license", "--skip-launch"])
+
+    assert excinfo.value.code == 2
+
+
+def test_main_task_requires_accept_license(mocker: pytest.MockFixture) -> None:
     mocker.patch("victoria_terminal.ensure_app_home")
     mocker.patch("victoria_terminal.load_environment")
     mocker.patch("victoria_terminal.generate_crush_config")
@@ -380,14 +386,18 @@ def test_main_no_banner_requires_license_acceptance(
     err = mocker.patch("victoria_terminal.err")
 
     with pytest.raises(SystemExit) as excinfo:
-        entrypoint.main(
-            [
-                "--skip-launch",
-                "--no-banner",
-                "--app-home",
-                str(tmp_path),
-            ]
-        )
+        entrypoint.main(["--task", "prompt"])
 
     assert excinfo.value.code == 2
     err.assert_called_once()
+
+
+def test_launch_crush_runs_task_with_yolo(tmp_path: Path, mocker: pytest.MockFixture) -> None:
+    execvp = mocker.patch("victoria_terminal.os.execvp")
+
+    entrypoint.launch_crush(app_home=tmp_path, task_prompt="Prime Directive")
+
+    execvp.assert_called_once()
+    args = execvp.call_args[0]
+    assert args[0] == entrypoint.CRUSH_COMMAND
+    assert args[1][3:] == ["run", "--yolo", "Prime Directive"]


### PR DESCRIPTION
## Summary
- require `--accept-license` whenever `--task` is used and drop the unused `--no-banner` flag
- update the entrypoint messaging, integration workflow, and docs to reference task mode for non-interactive runs
- extend the unit tests to cover the new requirements and ensure the task command forwards `--yolo` ahead of the prompt
- keep the test suite formatted to satisfy linting expectations

## Testing
- nox -s lint
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5a05648808332922b402e87f1c196