### PR TITLE
[CI] Fix integration workflow secret check

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,10 +15,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Ensure OPENROUTER_API_KEY secret is available
-        if: ${{ secrets.OPENROUTER_API_KEY == '' }}
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
-          echo "::error::OPENROUTER_API_KEY secret is not configured."
-          exit 1
+          if [ -z "${OPENROUTER_API_KEY}" ]; then
+            echo "::error::OPENROUTER_API_KEY secret is not configured."
+            exit 1
+          fi
 
       - name: Install Podman
         run: |


### PR DESCRIPTION
## Summary
- update the integration-test workflow to check OPENROUTER_API_KEY availability inside the shell script
- ensure the job fails with a clear error when the secret is missing without using the forbidden secrets context in the step condition

## Testing
- ./actionlint .github/workflows/integration-test.yml

------
https://chatgpt.com/codex/tasks/task_b_68d5b58d61388332ae461e62dad22e7e