### PR TITLE
[CI] Fix integration workflow secret validation

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,18 +10,16 @@ jobs:
     timeout-minutes: 20
     env:
       IMAGE: ghcr.io/elcanotek/victoria-terminal:latest
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Ensure OPENROUTER_API_KEY secret is available
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+        if: ${{ env.OPENROUTER_API_KEY == '' }}
         run: |
-          if [ -z "${OPENROUTER_API_KEY}" ]; then
-            echo "::error::OPENROUTER_API_KEY secret is not configured."
-            exit 1
-          fi
+          echo "::error::OPENROUTER_API_KEY secret is not configured."
+          exit 1
 
       - name: Install Podman
         run: |
@@ -46,8 +44,6 @@ jobs:
         run: mkdir -p victoria-home
 
       - name: Run Prime Directive integration check
-        env:
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
           set +e
           output=$(timeout 90s podman run --rm \


### PR DESCRIPTION
## Summary
- add the OPENROUTER_API_KEY secret to the job environment
- fail the integration workflow early when the secret is missing without using an invalid expression

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68d5b78971cc8332a19a4ab0ef4a785d