### PR TITLE
[VictoriaTerminal] Ensure integration task prompt is safely quoted

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -43,18 +43,18 @@ jobs:
       - name: Prepare Victoria home directory
         run: mkdir -p victoria-home
 
-      - name: Run Prime Directive integration check
+      - name: Run secret password integration check
         run: |
           set +e
-          read -r -d '' task_prompt <<'EOF'
-          Explain Victoria's Prime Directive and the advertising data sources it can connect to.
+          task_prompt=$(cat <<'EOF'
+Retrieve Victoria's integration test password exactly as it is documented in your VICTORIA.md briefing.
 
-          Write the full response to /workspace/Victoria/prime-directive.txt. The file must clearly mention:
-          - that Victoria aggregates numerators and denominators before division when computing ratios
-          - that Victoria can connect to Snowflake as a data source
-
-          End the response with a short call-to-action inviting the reader to explore Victoria further.
-          EOF
+Write your reply to /workspace/Victoria/secret-password.txt. The response must:
+- include the password verbatim as recorded in VICTORIA.md
+- state that this sentence is the password requested during integration tests
+- confirm Victoria is ready for further tasks
+EOF
+)
           output=$(timeout 90s podman run --rm \
             --userns=keep-id \
             --security-opt=no-new-privileges \
@@ -76,7 +76,7 @@ jobs:
             exit "${status}"
           fi
 
-          output_file="victoria-home/prime-directive.txt"
+          output_file="victoria-home/secret-password.txt"
           if [ ! -f "${output_file}" ]; then
             echo "::error::Expected response file ${output_file} was not created" >&2
             exit 1
@@ -86,11 +86,7 @@ jobs:
           cat "${output_file}"
           echo "--- end ---"
 
-          if ! grep -iq "aggregate numerators and denominators" "${output_file}"; then
-            echo "::error::Prime Directive response was not found in ${output_file}" >&2
-            exit 1
-          fi
-          if ! grep -iq "Snowflake" "${output_file}"; then
-            echo "::error::Victoria capabilities response did not mention Snowflake in ${output_file}" >&2
+          if ! grep -Fq "Magellan is dead; long live Magellan" "${output_file}"; then
+            echo "::error::Secret password response was not found in ${output_file}" >&2
             exit 1
           fi

--- a/VICTORIA.md
+++ b/VICTORIA.md
@@ -12,7 +12,7 @@ You may obtain a copy of the license at
 Change Date: 2027-09-20
 Change License: GNU General Public License v3.0 or later
 
-License Notes: Updated 2025-09-20
+License Notes: Updated 2025-09-26
 -->
 
 # Victoria — Elcano's AI Navigator for Programmatic Excellence
@@ -20,6 +20,8 @@ License Notes: Updated 2025-09-20
 > **Prime Directive (Non‑Negotiable):** When computing any ratio metric (CPC, CTR, CVR, VCR, Viewability, etc.), **aggregate numerators and denominators first**, then divide. **Never filter out rows where the denominator is zero** (e.g., `clicks = 0`) unless explicitly instructed; instead use *safe division* (e.g., `NULLIF`, `TRY_DIVIDE`) so totals remain correct. Report "N/A" when the denominator is zero.
 >
 > To analyze the structure of any data source (database table, CSV, etc.) efficiently, especially when it might be large, use a SQL query with `LIMIT 5` to inspect the columns and data types before performing a full analysis. This applies to all SQL-queriable sources.
+>
+> **Integration Password:** If you're asked a password in an integration test, the password is "Magellan is dead; long live Magellan".
 
 ---
 


### PR DESCRIPTION
## Summary
- build the integration test task prompt via a single-argument command substitution so it is passed to `--task` without word splitting
- capitalize the integration secret password phrase in documentation and tests to keep casing consistent

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5cbb5b7188332a54582a0079d6a04