### PR TITLE
[Container] Handle chown failures without CAP_CHOWN

### DIFF
--- a/container_entrypoint.sh
+++ b/container_entrypoint.sh
@@ -88,7 +88,9 @@ if [ "$(id -u)" = "0" ]; then
     # The Crush bootstrap config ships with restrictive permissions, so without
     # updating ownership the mapped UID would fail to read it and exit with the
     # "permission denied" error reported by users.
-    chown -R "${TARGET_UID}:${TARGET_GID}" "/home/${USERNAME}"
+    if ! chown -R "${TARGET_UID}:${TARGET_GID}" "/home/${USERNAME}"; then
+        echo "warning: unable to adjust ownership of /home/${USERNAME}; continuing with fallback if needed" >&2
+    fi
 
     # Re-execute the script as the victoria user, preserving the environment.
     # The `setpriv` command is used to drop root privileges and execute the


### PR DESCRIPTION
## Summary
- allow the entrypoint's ownership remap step to fail gracefully when the container runs without CAP_CHOWN
- emit a warning so users understand why the original home directory could not be remapped and rely on the fallback home if needed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5d812e82883329b35e0b0eb504a73