### PR TITLE
[Docs] Document task flag automation guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,14 @@ The same command on Windows stays on a single line and uses `$env:USERPROFILE/Vi
 
 > **Important:** Non-interactive runs triggered with `--task` must also pass `--accept-license`. Using this flag automatically accepts the Victoria Terminal Business Source License described in [LICENSE](LICENSE).
 
+Automated tasks run the same agent that powers the interactive terminal, so craft prompts that describe the real-world workflow you want to verify. Our default integration run asks Victoria to produce a Gamma presentation and email it to `brad@elcanotek.com`:
+
+```bash
+victoria --accept-license --task "create a Gamma presentation on this week's optimizations and email it to brad@elcanotek.com"
+```
+
+Update the quoted instruction to match your integration test or CI scenario. When you need artifacts written to disk, tell Victoria exactly which filenames to create inside `/workspace/Victoria` so your automation can pick them up after the container exits.
+
 ### 3. Configure on first run
 
 The container's default command (`victoria_terminal.py`) assumes you provide a ready-to-use `.env` file inside `~/Victoria`.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ victoria
 
 Re-run the script any time you want to refresh the alias. It will not reinstall Podman, but it will remind you to start `podman machine` on macOS and Windows if needed.
 
+### Automate Victoria with `--task`
+
+Victoria can execute non-interactive tasks when launched with the `--task` flag. Pair it with `--accept-license` so the container can acknowledge the Business Source License without prompting:
+
+```bash
+victoria --accept-license --task "create a Gamma presentation on this week's optimizations and email it to brad@elcanotek.com"
+```
+
+Use clear, production-ready instructions in the quoted task string—automation jobs frequently power integration tests and CI workflows. The example above mirrors the internal integration scenario we maintain; adapt the prompt to match the workflow you need to validate. When automations require filesystem output, specify both the filename and the directory inside your mounted `~/Victoria` workspace so downstream jobs can inspect the results.
+
 > **Need manual commands, pre-built image instructions, or the full development workflow?**
 > Head over to [CONTRIBUTING.md](CONTRIBUTING.md) for step-by-step guidance on running published container images and building Victoria from source.
 


### PR DESCRIPTION
## Summary
- add README instructions for launching Victoria in non-interactive task mode
- document the standard integration prompt and guidance for customizing task automation in CONTRIBUTING

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68d5e4fb55888332bc2fcc209ca5d711