### PR TITLE
[VictoriaTerminal] Require explicit VICTORIA_HOME configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ The container image exports `VICTORIA_HOME=/workspace/Victoria` by default, so m
 When you need to pass arguments through to Victoria, include `--` after the image name so Podman stops parsing options. For example:
 
 ```bash
-podman run --rm -it -v ~/Victoria:/workspace/Victoria ghcr.io/elcanotek/victoria-terminal:latest -- --skip-launch
+podman run --rm -it -v ~/Victoria:/workspace/Victoria ghcr.io/elcanotek/victoria-terminal:latest -- --accept-license
 ```
 
 The same command on Windows stays on a single line and uses `$env:USERPROFILE/Victoria` for the shared folder path.
@@ -81,13 +81,7 @@ The container's default command (`victoria_terminal.py`) assumes you provide a r
 - If `~/Victoria/.env` exists, Victoria loads the environment variables and launches immediately.
 - If the file is missing—or lacks a required key—it logs a warning that calls out which integrations will be unavailable until the `.env` file is updated.
 
-Victoria validates your `.env` file on every launch. Pass `--skip-launch` if you only want to perform the configuration checks without starting the UI:
-
-```bash
-podman run --rm -it \
-  -v ~/Victoria:/workspace/Victoria \
-  ghcr.io/elcanotek/victoria-terminal:latest -- --skip-launch
-```
+Victoria validates your `.env` file on every launch.
 
 You can also point the default command at an alternate shared location with `--shared-home /path/to/shared/Victoria`.
 
@@ -150,7 +144,7 @@ podman run --rm -it `
   victoria-terminal
 ```
 
-The entrypoint provisions a writable home directory, synchronizes configuration from your mounted workspace, and then launches the terminal UI. Append flags such as `-- --skip-launch` to run configuration checks without starting the UI.
+The entrypoint provisions a writable home directory, synchronizes configuration from your mounted workspace, and then launches the terminal UI.
 
 ## Workspace Layout
 

--- a/tests/test_victoria_terminal.py
+++ b/tests/test_victoria_terminal.py
@@ -15,9 +15,14 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
+
+TEST_APP_HOME = Path(__file__).resolve().parent / ".victoria-test-home"
+os.environ.setdefault("VICTORIA_HOME", str(TEST_APP_HOME))
+TEST_APP_HOME.mkdir(parents=True, exist_ok=True)
 
 import victoria_terminal as entrypoint
 
@@ -165,17 +170,17 @@ def test_generate_crush_config_missing_template_raises(tmp_path: Path) -> None:
         entrypoint.generate_crush_config(app_home=tmp_path, template_path=tmp_path / "missing.json")
 
 
-def test_parse_args_accepts_custom_app_home(tmp_path: Path) -> None:
-    args = entrypoint.parse_args(["--app-home", str(tmp_path), "--skip-launch"])
-
-    assert args.app_home == tmp_path
-    assert args.skip_launch is True
-
-
 def test_parse_args_ignores_double_dash_separator() -> None:
-    args = entrypoint.parse_args(["--", "--skip-launch"])
+    args = entrypoint.parse_args(["--", "--accept-license"])
 
-    assert args.skip_launch is True
+    assert args.accept_license is True
+
+
+def test_parse_args_rejects_app_home_override(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        entrypoint.parse_args(["--app-home", str(tmp_path)])
+
+    assert exc_info.value.code == 2
 
 
 def test_parse_args_sets_accept_license_flag() -> None:


### PR DESCRIPTION
## Summary
- remove the legacy --skip-launch command-line flag from the entrypoint
- adjust documentation and tests to reflect the simplified CLI
- drop the `--app-home` override so the container always uses the bundled home directory
- require `VICTORIA_HOME` to be set and remove fallback defaults from the terminal bootstrapper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5f16170c48332b43075fd6993ecc7