### PR TITLE
[MCP] Use SendGrid SDK for SendGrid server

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ rich
 scikit-learn
 scipy
 seaborn
+sendgrid
 sqlalchemy
 statsmodels
 xlsxwriter


### PR DESCRIPTION
## Summary
- switch the SendGrid MCP server to use the official sendgrid-python SDK
- add helper logic to reuse the SDK client and surface message IDs and errors consistently
- add the sendgrid dependency to the shared requirements list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68dd24fe6ae88332bc8a7217de474050