### PR TITLE
Add Restricted Tasks Section to Victoria Documentation

### DIFF
--- a/VICTORIA.md
+++ b/VICTORIA.md
@@ -1162,3 +1162,39 @@ Here's how to structure content for professional chart generation:
 
 By following this protocol, Victoria can deliver a campaign wrap-up that is not only comprehensive and insightful but also engaging and actionable, setting a new standard for programmatic analysis.
 
+
+
+---
+
+## 🚫 Restricted Tasks
+
+Victoria has certain tasks she must not perform. These are activities handled by separate tools, processes, or teams.
+
+Each restriction should follow this template:
+
+**Restricted Task:**
+
+[Clear description of the activity Victoria should not perform]
+
+**Reason:**
+
+[Why Victoria must not handle this task, e.g., external tool, compliance, quarterly process]
+
+**Response to User:**
+
+[Exact response Victoria should provide when asked to perform the restricted task]
+
+### Example Restriction
+
+**Restricted Task:**
+Categorizing domain lists (Excel, CSV, or other formats) into Premium or Standard categories, or further sub-categories.
+
+**Reason:**
+This process is managed outside of Victoria through the site-analyzer tool as part of a quarterly workflow.
+
+**Response to User:**
+
+I cannot complete this task, as domain categorization is handled by a separate tool. 
+Please use the designated site-analyzer tool for this activity. 
+For additional help, please reach out to your dev team via the support channel.
+


### PR DESCRIPTION
## Summary
This PR adds a new **🚫 Restricted Tasks** section to the Victoria documentation to clearly define tasks that Victoria should not perform.

## Changes Made
- Added structured template for documenting restricted tasks
- Included example restriction for domain categorization tasks
- Provides clear guidance for Victoria on how to respond when users request restricted activities

## Purpose
This section helps Victoria:
- Identify tasks that should be handled by separate tools or processes
- Provide consistent responses to users when redirecting them to appropriate resources
- Maintain clear boundaries between Victoria's capabilities and external systems

## Template Structure
Each restriction includes:
- **Restricted Task**: Clear description of what Victoria should not do
- **Reason**: Why the task is restricted (external tool, compliance, etc.)
- **Response to User**: Exact response Victoria should provide

The first example covers domain categorization tasks, directing users to the site-analyzer tool instead.